### PR TITLE
Fixed issues with simulator

### DIFF
--- a/FocusEntity-Example/FocusEntity-Example.xcodeproj/project.pbxproj
+++ b/FocusEntity-Example/FocusEntity-Example.xcodeproj/project.pbxproj
@@ -327,13 +327,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"FocusEntity-Example/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = GGXD5E6AF8;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "FocusEntity-Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.laurentb.focus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -346,13 +347,14 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"FocusEntity-Example/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = GGXD5E6AF8;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "FocusEntity-Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.laurentb.focus;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Sources/FocusEntity/FocusEntity+Alignment.swift
+++ b/Sources/FocusEntity/FocusEntity+Alignment.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Max Cobb. All rights reserved.
 //
 
-#if canImport(ARKit)
+#if canImport(ARKit) && !targetEnvironment(simulator)
 import RealityKit
 import ARKit
 import Combine

--- a/Sources/FocusEntity/FocusEntity+Classic.swift
+++ b/Sources/FocusEntity/FocusEntity+Classic.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Max Cobb. All rights reserved.
 //
 
-#if canImport(ARKit)
+#if canImport(ARKit) && !targetEnvironment(simulator)
 import RealityKit
 
 /// An extension of FocusEntity holding the methods for the "classic" style.

--- a/Sources/FocusEntity/FocusEntity+Colored.swift
+++ b/Sources/FocusEntity/FocusEntity+Colored.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Max Cobb. All rights reserved.
 //
 
-#if canImport(ARKit)
+#if canImport(ARKit) && !targetEnvironment(simulator)
 import RealityKit
 
 /// An extension of FocusEntity holding the methods for the "colored" style.

--- a/Sources/FocusEntity/FocusEntity.swift
+++ b/Sources/FocusEntity/FocusEntity.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Max Cobb. All rights reserved.
 //
 
-#if canImport(ARKit)
+#if canImport(ARKit) && !targetEnvironment(simulator)
 import RealityKit
 import ARKit
 import Combine


### PR DESCRIPTION
I have the AR code as part of a larger app and the project would not compile when ran un the simulator giving errors as ARview not found etc.   
This is a known problem and the fix is to avoid Xcode to compile that code when I am running on the simulator.  
Therefore I added/modified the existing line on the top from `#if canImport(ARKit)` to `#if canImport(ARKit) && !targetEnvironment(simulator)` for all files.

This did fix my problem, the package is ignored when I compile my app. 

I also think that maybe that line `canImport(ARKit)` is redundant because all iPhones being sold now are ARKit compatible. Unless you mean avoiding problems with the AppleWatch or TV? 

In any case thank you for this package! I am happy to have found a way to use it and hope others can do too!
