### PR TITLE
Fix transparent material color

### DIFF
--- a/Sources/FocusEntity/FocusEntity+Colored.swift
+++ b/Sources/FocusEntity/FocusEntity+Colored.swift
@@ -35,7 +35,8 @@ public extension FocusEntity {
                 modelMaterial = mat
             case .texture(let tex):
                 var mat = UnlitMaterial()
-                mat.color = .init(tint: .white.withAlphaComponent(0.9999), texture: .init(tex))
+                mat.baseColor = .texture(tex)
+                mat.tintColor = .white.withAlphaComponent(0.99)
                 modelMaterial = mat
             @unknown default: break
             }


### PR DESCRIPTION
It appear that the transparent material still show black/white background when implemented. 

This fix is doing a workaround from this reference:
https://forums.developer.apple.com/forums/thread/119265?answerId=374420022#374420022